### PR TITLE
Fix failing transfers_controller tests

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,15 +1,15 @@
 class UserMailer < ActionMailer::Base
   default :from => 'drxfer@example.com'
-  
+
   def transfer_confirmation(transfer)
     @transfer = transfer
-    mail(:to => transfer.user.email, 
+    mail(:to => transfer.user.email,
          :subject => Drxfer::Application.config.transfer_confirmation_subject)
   end
-  
+
   def transfer_notification(transfer)
-    @transfer = transfer    
-    mail(:to => ['drxfer.admin@example.com'], 
+    @transfer = transfer
+    mail(:to => ['drxfer.admin@example.com'],
          :subject => "A digital records transfer has been received")
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,11 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # For testing
+  config.transfer_confirmation_subject = 'Thank you'
+  config.transfer_confirmation_preamble = nil
+  config.transfer_confirmation_conclusion = 'Sincerely,'
+
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,6 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
-# ApplicationController.renderer.defaults.merge!(
-#   http_host: 'example.org',
-#   https: false
-# )
+# ActiveSupport::Reloader.to_prepare do
+#   ApplicationController.renderer.defaults.merge!(
+#     http_host: 'example.org',
+#     https: false
+#   )
+# end


### PR DESCRIPTION
There were three failing tests in `transfers_controller_spec` with the following error: 
`NoMethodError:
       undefined method 'transfer_confirmation_subject' for #<Rails::Application::Configuration:0x0000558f90259458>`.

The method is supposed to be implemented in `config/initializers/notifications.rb`. However, the file is not provided by default. To fix this, I've added the config variables that should be defined in the files to `config/environments/test.rb`. 

All tests should pass now after running `rspec`.