### PR TITLE
Update Gemfile.lock and db/schema.rb 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,9 @@ GEM
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    passenger (5.3.7)
+      rack
+      rake (>= 0.8.1)
     pg (1.1.4)
     power_assert (1.1.5)
     public_suffix (4.0.1)
@@ -274,7 +277,8 @@ DEPENDENCIES
   jquery-rails (~> 4.3.5)
   json (~> 2.2.0)
   listen (~> 3.2.1)
-  pg (~> 1.1.4)
+  passenger (~> 5.3.2)
+  pg
   rails (~> 5.2.3)
   rails-controller-testing
   rake (= 12.1.0)
@@ -290,4 +294,4 @@ DEPENDENCIES
   webrat (~> 0.7.3)
 
 BUNDLED WITH
-   1.15.4
+   1.17.3

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20111207023448) do
+ActiveRecord::Schema.define(version: 2011_12_07_023448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
These two files changed locally when I most recently ran `bundle install` to get the passenger gem and rest the database for testing in Docker. The version committed here is what I _already_ tested and merged, and this PR essentially catches the side effects of the configuration up with the configuration.