### PR TITLE
Restore use of configuration variables to specify mailer addresses

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,5 @@
 class UserMailer < ActionMailer::Base
-  default :from => 'drxfer@example.com'
+  default :from => Drxfer::Application.config.email_notification_from_address
 
   def transfer_confirmation(transfer)
     @transfer = transfer
@@ -9,7 +9,7 @@ class UserMailer < ActionMailer::Base
 
   def transfer_notification(transfer)
     @transfer = transfer
-    mail(:to => ['drxfer.admin@example.com'],
+    mail(:to => Drxfer::Application.config.transfer_notification_recipient_addresses, 
          :subject => "A digital records transfer has been received")
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,8 +52,14 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+  config.transfer_destination_base_path = Rails.root.to_s + '/'+ 'public' + '/'+ 'uploads'
+  config.transfer_destination_base_path_description = 'the <code>public/uploads</code> folder.'
+
   # Enable the console in a VM-based dev environment
   if Rails.env.development? && ENV.key?('VM_HOST_ADDRESS')
     config.web_console.whitelisted_ips = ENV['VM_HOST_ADDRESS']
   end
+
+  config.email_notification_from_address = 'drxfer@example.com'
+  config.transfer_notification_recipient_addresses = ['drxfer.admin@example.com']
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,4 +48,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.email_notification_from_address = 'drxfer@example.com'
+  config.transfer_notification_recipient_addresses = ['drxfer.admin@example.com']
 end


### PR DESCRIPTION
A 2017 commit, [1769492](https://github.com/mtholyoke/drxfer/commit/1769492b1fd1386f699cbe24b6041074e01549f4#diff-26b9feff8901b30987232edf46f21e05bbe190689d342ec2fa5328b559ce7524), introduced a regression which was merged in #4. Specifically, it removed the configuration variables email_notification_from_address and transfer_notification_recipient_addresses out of development.rb and test.rb and hard-coded their default values in user_mailer.rb. This is fine for development and test, but it's not fine for production, where installations expect to override those default values in their live production.rb copy of production.rb.sample.