### PR TITLE
Revert "Bump nokogiri from 1.10.10 to 1.13.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "devise_ldap_authenticatable", "~> 0.8.6"
 gem 'passenger', '~> 5.3.2', require: 'phusion_passenger/rack_handler'
 
 gem 'carrierwave', '~> 2.1.1'
-gem 'nokogiri', '~> 1.13.2'
+gem 'nokogiri', '~> 1.10.10'
 
 gem 'capistrano', "~> 2.14.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       rake
     mini_magick (4.11.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.8.0)
+    mini_portile2 (2.4.0)
     minitest (5.14.4)
     net-ldap (0.16.2)
     net-scp (2.0.0)
@@ -142,9 +142,8 @@ GEM
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
     nio4r (2.5.7)
-    nokogiri (1.13.2)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     passenger (5.3.7)
       rack
@@ -152,7 +151,6 @@ GEM
     pg (1.1.4)
     power_assert (1.1.5)
     public_suffix (4.0.6)
-    racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -282,7 +280,7 @@ DEPENDENCIES
   jquery-rails (~> 4.3.5)
   json (~> 2.3.0)
   listen (~> 3.2.1)
-  nokogiri (~> 1.13.2)
+  nokogiri (~> 1.10.10)
   passenger (~> 5.3.2)
   pg
   rails (~> 5.2.5)


### PR DESCRIPTION
Reverts mtholyoke/drxfer#37

Accidentally merged #37 instead of #35. #37 cannot proceed until Ruby is updated.